### PR TITLE
feat: add debt (underlying) field to StrategyConfigPayload

### DIFF
--- a/src/common-utils/static/strategy.ts
+++ b/src/common-utils/static/strategy.ts
@@ -24,6 +24,12 @@ export interface StrategyConfigPayload {
    */
   tokenOutAddress: Address;
   /**
+   * Underlying token borrowed against the collateral (the debt side of the
+   * (collateral, debt) pair). Equals `underlying()` of every credit manager
+   * listed in `creditManagers`.
+   */
+  debt: Address;
+  /**
    * Chain id and network type as they are written in sdk. Wrong entries are being omitted
    */
   chainId: number;


### PR DESCRIPTION
## What

Adds a `debt: Address` field to `StrategyConfigPayload` (`src/common-utils/static/strategy.ts`).

`debt` is the borrowed underlying — the **debt** side of a (collateral, debt) pair, where `tokenOutAddress` is the collateral. It equals `underlying()` of every credit manager listed in `creditManagers`.

## Why

Preparation for the agentic approach: the static strategies list is being remodeled so each entry is a single **(collateral, debt) pair** with the set of credit managers that service it, instead of one collateral umbrella-ing credit managers across multiple debts. Carrying `debt` explicitly lets a strategy be keyed/reasoned about as a discrete pair without resolving it from a credit manager at runtime.

`id` is intentionally **kept** — this is a non-breaking, additive change. `StrategyRecord` keying is unchanged.

## Companion PR

The static data is reshaped in **Gearbox-protocol/static** (separate PR) to populate `debt` and split collaterals that span two debts into separate pairs. That PR depends on this field landing + a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)